### PR TITLE
Fix README data function docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ emojiFlags.countryCode('DK');
 // => { "code": "DK", "emoji": "🇩🇰", ... }
 
 // entire dataset
-emojiFlags.data;
+emojiFlags.data();
 ```
 
 


### PR DESCRIPTION
Fixed the docs for the `data` function, which was missing `()`, can't believe nobody caught this in so many years. 😉